### PR TITLE
fix CSP format for external stylesheet

### DIFF
--- a/built-in
+++ b/built-in
@@ -9,7 +9,7 @@
 
 	<meta http-equiv="Content-Security-Policy" content="
 		default-src 'none';
-		style-src 'nonce-{{.Metadata.nonce}}'{{if .Metadata.stylesheet}}'{{.Metadata.stylesheet}}'{{end}} ;
+		style-src 'nonce-{{.Metadata.nonce}}'{{if .Metadata.stylesheet}} {{.Metadata.stylesheet}}{{end}} ;
     ">
 	<meta name="application-name" content="tinyfeed">
 	<meta name="application-source" content="https://github.com/TheBigRoomXXL/tinyfeed">


### PR DESCRIPTION
Thanks for this very cool project! I'm really impressed with it so far.

I was having a hard time getting tinyfeed to work with an external stylesheet. Trying to pass *any* CSS with the `--stylesheet` argument would result in a completely unstyled page. I (eventually) realized it was due to the Content Security Policy:

```
The source list for the Content Security Policy directive 'style-src' contains an invalid source: ''nonce-BKZn[...]WjQ==''https://cdn.example.com/css/style.css''. It will be ignored.
```

There (apparently) should be a space between the nonce and the stylesheet, and the external stylesheet should not be wrapped in single quotes. Once I made those tweaks I was able to successfully apply my CSS.